### PR TITLE
Allow to configure the deployment phase to use when starting the health monitor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,9 @@
 HEALTHMONITOR_SERVER_SCHEME=http
 HEALTHMONITOR_SERVER_ADDRESS=127.0.0.1
 HEALTHMONITOR_SERVER_PORT=8080
-HEALTHMONITOR_INTERVAL=60
-HEALTHMONITOR_DEPLOY_TIMEOUT=600
+
+# The default deployment phase when the health monitor starts.
+HEALTHMONITOR_DEPLOYMENT_PHASE=online
 
 # Comma separates list of files to check. The check will fail if any of the files do not exist or are empty. Leave empty
 # to disable file checks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -170,9 +170,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bumpalo"
@@ -182,9 +182,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cfg-if"
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -684,9 +684,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -712,9 +712,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -840,27 +840,27 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
@@ -951,15 +951,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scc"
@@ -1004,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -1109,9 +1109,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1154,18 +1154,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1282,9 +1282,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "url"
@@ -1579,18 +1579,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/checks/plugin_manager.rs
+++ b/src/checks/plugin_manager.rs
@@ -1,5 +1,6 @@
 use crate::checks::file_check::FileCheck;
 use crate::checks::HealthCheck;
+use crate::config::CONFIG;
 use crate::status::{DeploymentPhase, Status};
 use log::{debug, error};
 use std::sync::Arc;
@@ -77,5 +78,5 @@ impl PluginManager {
 }
 
 fn create_plugins() -> Vec<Arc<dyn HealthCheck + Send + Sync>> {
-    vec![Arc::new(FileCheck::new())]
+    vec![Arc::new(FileCheck::new(&CONFIG))]
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::status::DeploymentPhase;
 use std::sync::LazyLock;
 use std::{env, fmt};
 
@@ -15,6 +16,12 @@ impl Config {
             .ok()
             .and_then(|p| p.parse().ok())
             .unwrap_or(8080);
+        let phase = DeploymentPhase::try_from(
+            env::var("HEALTHMONITOR_SERVER_PHASE")
+                .unwrap_or_else(|_| "online".to_string())
+                .as_str(),
+        )
+        .unwrap_or(DeploymentPhase::Online);
 
         let file_check_interval = env::var("HEALTHMONITOR_FILECHECK_INTERVAL")
             .ok()
@@ -32,6 +39,7 @@ impl Config {
                 scheme,
                 address,
                 port,
+                phase,
             },
             checks: ChecksConfig {
                 file_check: FileCheckConfig {
@@ -55,6 +63,7 @@ pub struct ServerConfig {
     pub scheme: String,
     pub address: String,
     pub port: u16,
+    pub phase: DeploymentPhase,
 }
 
 impl fmt::Debug for ServerConfig {

--- a/src/server.rs
+++ b/src/server.rs
@@ -202,7 +202,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let expected = r#"{"state":"healthy","messages":[],"phase":"deploying"}"#;
+        let expected = r#"{"state":"healthy","messages":[],"phase":"online"}"#;
         let body = response.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(&body[..], expected.as_bytes());
     }
@@ -263,11 +263,6 @@ mod tests {
     async fn test_patch_phase() {
         let status = Arc::new(Mutex::new(Status::new()));
         let app = create_router(status.clone());
-        assert_eq!(status.lock().await.phase, DeploymentPhase::Deploying);
-
-        let payload = json!({ "phase": "online" });
-        let response = get_patch_response(&app, payload).await;
-        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(status.lock().await.phase, DeploymentPhase::Online);
 
         let payload = json!({ "phase": "deploying" });
@@ -275,10 +270,15 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(status.lock().await.phase, DeploymentPhase::Deploying);
 
+        let payload = json!({ "phase": "online" });
+        let response = get_patch_response(&app, payload).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(status.lock().await.phase, DeploymentPhase::Online);
+
         let payload = json!({ "phase": "invalid" });
         let response = get_patch_response(&app, payload).await;
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        assert_eq!(status.lock().await.phase, DeploymentPhase::Deploying);
+        assert_eq!(status.lock().await.phase, DeploymentPhase::Online);
     }
 
     async fn get_patch_response(app: &Router, payload: Value) -> Response<Body> {

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,3 +1,4 @@
+use crate::config::CONFIG;
 use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -14,7 +15,7 @@ impl Status {
         Status {
             state: HealthState::Healthy,
             messages: Vec::new(),
-            phase: DeploymentPhase::Deploying,
+            phase: CONFIG.server.phase.clone(),
         }
     }
 
@@ -39,7 +40,7 @@ impl fmt::Display for Status {
     }
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum DeploymentPhase {
     #[serde(rename = "deploying")]
     Deploying,
@@ -133,7 +134,7 @@ mod tests {
         let status = Status::new();
         assert_eq!(status.state, HealthState::Healthy);
         assert!(status.messages.is_empty());
-        assert_eq!(status.phase, DeploymentPhase::Deploying);
+        assert_eq!(status.phase, DeploymentPhase::Online);
     }
 
     #[test]

--- a/tests/status_tests.rs
+++ b/tests/status_tests.rs
@@ -248,15 +248,15 @@ async fn test_phase() {
     check_log_output_regex(lines.clone(), expected_lines).await;
     assert_exit_code(phase_command, 1).await;
 
-    // Start the server. Now `cargo run -- phase get` should return `deploying`.
+    // Start the server. Now `cargo run -- phase get` should return `online`.
     let mut server = TestServer::start().await;
-    assert_phase(DeploymentPhase::Deploying).await;
-
-    // Switch the application to online mode. The phase should then be reported as online.
-    let (update_phase_command, _stdout, _stderr) =
-        execute_phase_command(SubCommands::Set, ["online".to_string()].to_vec()).await;
-    assert_exit_code(update_phase_command, 0).await;
     assert_phase(DeploymentPhase::Online).await;
+
+    // Switch the application to deploying mode. The phase should then be reported as such.
+    let (update_phase_command, _stdout, _stderr) =
+        execute_phase_command(SubCommands::Set, ["deploying".to_string()].to_vec()).await;
+    assert_exit_code(update_phase_command, 0).await;
+    assert_phase(DeploymentPhase::Deploying).await;
 
     // Stop the server. We should get an error when we try to get the phase.
     server.stop().await;


### PR DESCRIPTION
Also set the default deployment phase to `online` since that will be the most common state for a newly provisioned instance.